### PR TITLE
FIX: Directories with 0 entries will raise error

### DIFF
--- a/zip_single_archive_reader.ts
+++ b/zip_single_archive_reader.ts
@@ -70,9 +70,13 @@ export class ZipSingleArchiveReader implements FileSystemReader {
 
     const result = this.#contents?.get(pathInZipFile);
     if (!result) {
-      throw new Error(
-        `There is no directory at path "${pathInZipFile}" in zip file`,
+      // if pathInZipFile is an empty directory, this will throw an error return empty array
+      return Promise.resolve(
+        new DirectoryContentsWithReaderReference(this, [])
       );
+      /*throw new Error(
+        `There is no directory at path "${pathInZipFile}" in zip file`,
+      );*/
     }
 
     const entries = result.map(makeDirectoryEntry);


### PR DESCRIPTION
When a directory contains 0 entries the method `this.#contents?.get(pathInZipFile)` in `zip_single_archive_reader.ts/readDirectoryContents` raises an error!

![image](https://github.com/user-attachments/assets/6940a739-1aee-429d-a2a7-8664bcc578c6)

To prevent this, if `this.#contents?.get(pathInZipFile)` returns undefined, just returns emtpy entries array.

Maybe there is a better way to handle this but i need a fast solution to use this module in my project.